### PR TITLE
Prevent crash when PATH contains empty substring

### DIFF
--- a/app/source/controller.cpp
+++ b/app/source/controller.cpp
@@ -1056,6 +1056,8 @@ auto Controller::getEnvPaths () -> StringList
 		std::string el;
 		while (std::getline (input, el, EnvPathSeparator))
 		{
+			if (el.empty())
+				continue;
 			if (*el.rbegin () != PlatformPathDelimiter)
 				el += PlatformPathDelimiter;
 			result.emplace_back (std::move (el));


### PR DESCRIPTION
On windows the environment PATH can sometimes contain two consecutive semicolons which will result in an empty path that crashes the application when the iterator(`*el.rbegin()`) is dereferenced.