### PR TITLE
Add getProcessContextRequirements

### DIFF
--- a/script/cmake/templates/vst3plugin_folder/source/vst3pluginprocessor.cpp.in
+++ b/script/cmake/templates/vst3plugin_folder/source/vst3pluginprocessor.cpp.in
@@ -128,4 +128,11 @@ tresult PLUGIN_API @SMTG_PLUGIN_CLASS_NAME@Processor::getState (IBStream* state)
 }
 
 //------------------------------------------------------------------------
+uint32 PLUGIN_API @SMTG_PLUGIN_CLASS_NAME@Processor::getProcessContextRequirements ()
+{
+    // add your own required Context Requirements
+    return IProcessContextRequirements::kNeedTempo | IProcessContextRequirements::kNeedTimeSignature;
+}
+
+//------------------------------------------------------------------------
 } // namespace @SMTG_VENDOR_NAMESPACE@

--- a/script/cmake/templates/vst3plugin_folder/source/vst3pluginprocessor.h.in
+++ b/script/cmake/templates/vst3plugin_folder/source/vst3pluginprocessor.h.in
@@ -48,6 +48,9 @@ public:
 	Steinberg::tresult PLUGIN_API setState (Steinberg::IBStream* state) SMTG_OVERRIDE;
 	Steinberg::tresult PLUGIN_API getState (Steinberg::IBStream* state) SMTG_OVERRIDE;
 
+	/** Process Context Requirements */
+	uint32 PLUGIN_API getProcessContextRequirements () SMTG_OVERRIDE;
+
 //------------------------------------------------------------------------
 protected:
 


### PR DESCRIPTION
Because this methode is mandatory to update the ProcessContext it should be in the Project Generator